### PR TITLE
Avoid running tests with old Perls on new systems

### DIFF
--- a/t/test-data.t
+++ b/t/test-data.t
@@ -11,16 +11,20 @@ use File::Slurper qw(read_text);
 use Test::More 0.96;
 require "testlib.pl";
 
-test_to_html(
-    name => 'example.org',
-    args => {
-        source_file=>"$Bin/data/example.org",
-        html_title => 'Example',
-        css_url => 'style.css',
-    },
-    status => 200,
-    result => scalar read_text("$Bin/data/example.org.html"),
-);
+# Perl versions < 5.14 don't work with today's UTF-8-based locales,
+# leading to a wrong parse result.  So skip the test for old Perls:
+if ($] > 5.012) {
+    test_to_html(
+        name => 'example.org',
+        args => {
+            source_file=>"$Bin/data/example.org",
+            html_title => 'Example',
+            css_url => 'style.css',
+        },
+        status => 200,
+        result => scalar read_text("$Bin/data/example.org.html"),
+    );
+}
 
 test_to_html(
     name => 'example.org',


### PR DESCRIPTION
CPAN Testers report errors in the test suite for old Perl versions: http://www.cpantesters.org/distro/O/Org-To-HTML.html

The root cause is that old Perl versions' "use locale" (as in Org::Document) doesn't play well with current systems which have UTF-8-based locales, so actually it is the parser which fails and not the converter.  The converter should simply skip the tests on old versions because I'd guess it is safe to assume that these old Perl versions are only in use on older operating systems - where the parser works quite fine.