### PR TITLE
Remove unneeded modules

### DIFF
--- a/lib/Org/To/HTML/Link/cpandist.pm
+++ b/lib/Org/To/HTML/Link/cpandist.pm
@@ -1,7 +1,0 @@
-package Org::To::HTML::Link::cpandist;
-
-# DATE
-# VERSION
-
-1;
-# ABSTRACT: cpandist

--- a/lib/Org/To/HTML/Link/cpanmod.pm
+++ b/lib/Org/To/HTML/Link/cpanmod.pm
@@ -1,7 +1,0 @@
-package Org::To::HTML::Link::cpanmod;
-
-# DATE
-# VERSION
-
-1;
-#ABSTRACT: cpanmod


### PR DESCRIPTION
The two modules Org::To::HTML::Link::cpandist and Org::To::HTML::Link::cpanmod don't have content yet, so they can be safely removed from the distribution.  As a positive side effect, this will calm down CPANTS complaints (https://cpants.cpanauthors.org/dist/Org-To-HTML).
