### PR TITLE
Point org-to-html documentation to App::OrgUtils

### DIFF
--- a/lib/Org/To/HTML.pm
+++ b/lib/Org/To/HTML.pm
@@ -427,7 +427,8 @@ sub export_link {
 
 Export Org format to HTML. To customize, you can subclass this module.
 
-A command-line utility is included: L<org-to-html>.
+A command-line utility L<org-to-html> is available in the distribution
+L<App::OrgUtils>.
 
 Note that this module is just a simple exporter, for "serious" works you'll
 probably want to use the exporting features or L<org-mode|http://orgmode.org>.


### PR DESCRIPTION
Doc fix: The script org-to-html is no longer _included_ in Org-To-HTML, so point to App::OrgUtils instead. This is my last PR for the October round of the CPAN Pull Request Challenge.